### PR TITLE
remove read only props recursively

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -44,6 +44,21 @@ Object {
 }
 `;
 
+exports[`Reva .validate() invalid requests should handle invalid readonly props 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "context": Object {
+        "errorType": "additionalProperties",
+      },
+      "message": "'world' property is not expected to be here",
+      "path": "request.body.hello",
+    },
+  ],
+  "ok": false,
+}
+`;
+
 exports[`Reva .validate() invalid requests should handle missing required parameters 1`] = `
 Object {
   "errors": Array [

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -378,6 +378,53 @@ describe('Reva', () => {
         expect(result.ok).toBe(false);
         expect(result).toMatchSnapshot();
       });
+
+      it('should handle invalid readonly props', () => {
+        const reva = new Reva();
+        const result = reva.validate({
+          operation: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    required: ['foo'],
+                    additionalProperties: false,
+                    properties: {
+                      foo: {
+                        type: 'string',
+                      },
+                      hello: {
+                        type: 'object',
+                        additionalProperties: false,
+                        properties: {
+                          world: {
+                            type: 'string',
+                            readOnly: true,
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          request: {
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: {
+              foo: 'value',
+              hello: {
+                world: 'value',
+              },
+            },
+          },
+        });
+        expect(result.ok).toBe(false);
+        expect(result).toMatchSnapshot();
+      });
     });
 
     describe('options', () => {


### PR DESCRIPTION
## Description

Read only props were only removed on the root level.
This leads to Reva successfully validating a request body that has nested read only fields.

## Fix

This PR removes read only props recursively. Now you will get an error of type `additionalProperties` if you pass a nested read only field when the object has `additionalProperties` is set to `false`.

You can still add nested properties to objects where additional properties are allowed.

## Tests
- [x] Unit tests